### PR TITLE
Add File.join(__dir__, "filename") method instead of hardcoded "filename" for wordlist

### DIFF
--- a/lazys3.rb
+++ b/lazys3.rb
@@ -94,7 +94,7 @@ class Wordlist
   end
 end
 
-wordlist = Wordlist.from_file(ARGV[0], 'common_bucket_prefixes.txt')
+wordlist = Wordlist.from_file(ARGV[0], File.join(__dir__, 'common_bucket_prefixes.txt'))
 
 puts "Generated wordlist from file, #{wordlist.length} items..."
 


### PR DESCRIPTION
Add File.join(__dir__, "filename") method instead of hardcoded "filename" for the wordlist.

Previously, the script must be run from the directory where the wordlist file was present.
Now, the wordlist file must on the path where the script is present. Therefore, creating symlinks would also work.